### PR TITLE
tbrekalo-matcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 project(
   ram
-  VERSION 2.2.0
+  VERSION 3.0.0
   LANGUAGES CXX
   DESCRIPTION
     "Ram is a c++ implementation of [minimap](https://github.com/lh3/minimap) with few modifications."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,20 @@ if(NOT biosoup_FOUND)
   endif()
 endif()
 
+if(ram_build_exe)
+  FetchContent_Declare(
+    cxxopts
+    GIT_REPOSITORY https://github.com/jarro2783/cxxopts
+    GIT_TAG v3.1.1)
+
+  FetchContent_GetProperties(cxxopts)
+  if(NOT cxxopts_POPULATED)
+    FetchContent_Populate(cxxopts)
+    add_subdirectory(${cxxopts_SOURCE_DIR} ${cxxopts_BINARY_DIR}
+                     EXCLUDE_FROM_ALL)
+  endif()
+endif()
+
 if(ram_build_exe OR ram_build_tests)
   find_package(bioparser 3.0.13 QUIET)
   if(NOT bioparser_FOUND)
@@ -104,14 +118,14 @@ if(ram_build_benchmarks)
   endif()
 endif()
 
-add_library(ram src/algorithm.cpp src/types.cpp)
+add_library(ram src/algorithm.cpp src/io.cpp src/types.cpp)
 add_library(ram::ram ALIAS ram)
 
 target_include_directories(
   ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                          $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(ram biosoup::biosoup TBB::tbb)
+target_link_libraries(ram bioparser::bioparser biosoup::biosoup TBB::tbb)
 
 target_compile_options(
   ram
@@ -167,7 +181,7 @@ endif()
 if(ram_build_exe)
   add_executable(ram_exe src/main.cpp)
 
-  target_link_libraries(ram_exe ram bioparser::bioparser)
+  target_link_libraries(ram_exe ram cxxopts::cxxopts)
 
   target_compile_definitions(ram_exe PRIVATE VERSION="${PROJECT_VERSION}")
   set_property(TARGET ram_exe PROPERTY OUTPUT_NAME ram)

--- a/README.md
+++ b/README.md
@@ -17,44 +17,48 @@ cmake -DCMAKE_BUILD_TYPE=Release .. && make
 which will create ram library, executable and unit tests. Running the executable will display the following usage:
 
 ```bash
-usage: ram [options ...] <target> [<sequences>]
+sequence mapping tool
+Usage:
+  ram [OPTION...] <target> [<query>]
 
-  # default output is stdout
-  <target>/<sequences>
-    input file in FASTA/FASTQ format (can be compressed with gzip)
+ algorithm options:
+  -k, --kmer-length arg         length of minimizers (default: 15)
+  -w, --window-length arg       length of sliding window from which 
+                                minimizers are sampled (default: 5)
+  -f, --frequency-threshold arg
+                                threshold for ignoring most frequent 
+                                minimizers (default: 0.001)
+      --bandwidth arg           size of bandwidth in which minimizer hits 
+                                can be chained (default: 500)
+      --chain arg               minimal number of chained minimizer hits in 
+                                overlap (default: 4)
+      --matches arg             minimal number of matching bases in overlap 
+                                (default: 100)
+      --gap arg                 maximal gap between minimizer hits in a 
+                                chain (default: 10000)
+      --minhash                 use only a portion of all minimizers
+  -t, --threads arg             number of threads (default: 1)
 
-  options:
-    -k, --kmer-length <int>
-      default: 15
-      length of minimizers
-    -w, --window-length <int>
-      default: 5
-      length of sliding window from which minimizers are sampled
-    -f, --frequency-threshold <float>
-      default: 0.001
-      threshold for ignoring most frequent minimizers
-    --bandwidth <int>
-      default: 500
-      size of bandwidth in which minimizer hits can be chained
-    --chain <int>
-      default: 4
-      minimal number of chained minimizer hits in overlap
-    --matches <int>
-      default: 100
-      minimal number of matching bases in overlap
-    --gap <int>
-      default: 10000
-      maximal gap between minimizer hits in a chain
-    --minhash
-      use only a portion of all minimizers
-    -t, --threads <int>
-      default: 1
-      number of threads
-    --version
-      prints the version number
-    -h, --help
-      prints the usage
+ info options:
+  -v, --version  print version and exit early
+  -h, --help     print help and exit early
+
+ mode options:
+      --mode arg  ram operating mode (match|overlap) (default: overlap)
+
 ```
+
+## Modes
+
+There are two output modes. `Overlap` mode outputs standard overlaps between sequences in paf format. While `match` mode provides more detail printing matches in tsv format.
+
+### Match tsv implicit header
+
+```txt
+query_name query_length query_match_position strand target_name target_length target_match_position
+```
+
+## Installation
 
 Running `make install` will install the executable. In order to install the library, both biosoup and thread_pool (see Dependencies) need to be installed beforehand, and option `ram_install` used while configuring the build. Once the library is installed, a package will be copied to your system that can be searched and linked with:
 

--- a/include/ram/algorithm.hpp
+++ b/include/ram/algorithm.hpp
@@ -134,9 +134,11 @@ struct ChainConfig {
   std::uint64_t gap = 10'000;
 };
 
-std::vector<biosoup::Overlap> Chain(std::uint64_t lhs_id,
-                                    std::vector<Match>&& matches,
-                                    ChainConfig config);
+// Find matches between a pair of sequences.
+// Minhash argument from configuration will only be applied on the lhs sequence.
+std::vector<Match> MatchPairs(const std::unique_ptr<biosoup::NucleicAcid>& lhs,
+                              const std::unique_ptr<biosoup::NucleicAcid>& rhs,
+                              MinimizeConfig minimize_config);
 
 // Find overlaps between a pair of sequences.
 // Minhash argument from configuration will only be applied on the lhs sequence.
@@ -151,7 +153,18 @@ struct MapToIndexConfig {
   std::uint32_t occurrence = -1;
 };
 
-std::vector<biosoup::Overlap> MapSeqToIndex(
+std::vector<Match> MatchToIndex(
+    const std::unique_ptr<biosoup::NucleicAcid>& sequence,
+    const std::vector<Index>& indices, MapToIndexConfig map_config,
+    MinimizeConfig minimize_config, ChainConfig chain_config,
+    std::vector<std::uint32_t>* filtered);
+
+// Chain matches into overlaps.
+std::vector<biosoup::Overlap> Chain(std::uint64_t lhs_id,
+                                    std::vector<Match>&& matches,
+                                    ChainConfig config);
+
+std::vector<biosoup::Overlap> MapToIndex(
     const std::unique_ptr<biosoup::NucleicAcid>& sequence,
     const std::vector<Index>& indices, MapToIndexConfig map_config,
     MinimizeConfig minimize_config, ChainConfig chain_config,

--- a/include/ram/algorithm.hpp
+++ b/include/ram/algorithm.hpp
@@ -109,12 +109,6 @@ inline std::vector<std::uint64_t> LongestMatchSubsequence(
   return dst;
 }
 
-struct MinimizeConfig {
-  std::uint32_t kmer_length = 15;
-  std::uint32_t window_length = 5;
-  bool minhash = false;
-};
-
 std::vector<Kmer> Minimize(
     const std::unique_ptr<biosoup::NucleicAcid>& sequence,
     MinimizeConfig config);
@@ -126,13 +120,6 @@ std::vector<Index> ConstructIndices(
 std::uint32_t CalculateKmerThreshold(std::vector<Index> indices,
                                      double frequency);
 
-struct ChainConfig {
-  std::uint32_t kmer_length = 15;
-  std::uint32_t bandwidth = 500;
-  std::uint32_t chain = 4;
-  std::uint32_t min_matches = 100;
-  std::uint64_t gap = 10'000;
-};
 
 // Find matches between a pair of sequences.
 // Minhash argument from configuration will only be applied on the lhs sequence.
@@ -147,15 +134,9 @@ std::vector<biosoup::Overlap> MapPairs(
     const std::unique_ptr<biosoup::NucleicAcid>& rhs,
     MinimizeConfig minimize_config, ChainConfig chain_config);
 
-struct MapToIndexConfig {
-  bool avoid_equal = true;
-  bool avoid_symmetric = true;
-  std::uint32_t occurrence = -1;
-};
-
 std::vector<Match> MatchToIndex(
     const std::unique_ptr<biosoup::NucleicAcid>& sequence,
-    const std::vector<Index>& indices, MapToIndexConfig map_config,
+    std::span<const Index> indices, MapToIndexConfig map_config,
     MinimizeConfig minimize_config, ChainConfig chain_config,
     std::vector<std::uint32_t>* filtered);
 
@@ -166,7 +147,7 @@ std::vector<biosoup::Overlap> Chain(std::uint64_t lhs_id,
 
 std::vector<biosoup::Overlap> MapToIndex(
     const std::unique_ptr<biosoup::NucleicAcid>& sequence,
-    const std::vector<Index>& indices, MapToIndexConfig map_config,
+    std::span<const Index> indices, MapToIndexConfig map_config,
     MinimizeConfig minimize_config, ChainConfig chain_config,
     std::vector<std::uint32_t>* filtered);
 

--- a/include/ram/io.hpp
+++ b/include/ram/io.hpp
@@ -2,20 +2,29 @@
 #define RAM_IO_HPP_
 
 #include <memory>
+#include <ostream>
+#include <span>
 
 #include "bioparser/parser.hpp"
 
 namespace biosoup {
 
 class NucleicAcid;
+struct Overlap;
 
-}
+}  // namespace biosoup
 
 namespace ram {
 
 std::unique_ptr<bioparser::Parser<biosoup::NucleicAcid>> CreateParser(
     const std::string& path);
 
-}
+void PrintOverlapBatch(
+    std::ostream& ostrm,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> batch_targets,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> batch_queries,
+    std::span<const std::vector<biosoup::Overlap>> overlaps);
+
+}  // namespace ram
 
 #endif  // RAM_IO_HPP_

--- a/include/ram/io.hpp
+++ b/include/ram/io.hpp
@@ -1,0 +1,21 @@
+#ifndef RAM_IO_HPP_
+#define RAM_IO_HPP_
+
+#include <memory>
+
+#include "bioparser/parser.hpp"
+
+namespace biosoup {
+
+class NucleicAcid;
+
+}
+
+namespace ram {
+
+std::unique_ptr<bioparser::Parser<biosoup::NucleicAcid>> CreateParser(
+    const std::string& path);
+
+}
+
+#endif  // RAM_IO_HPP_

--- a/include/ram/io.hpp
+++ b/include/ram/io.hpp
@@ -6,6 +6,7 @@
 #include <span>
 
 #include "bioparser/parser.hpp"
+#include "ram/types.hpp"
 
 namespace biosoup {
 
@@ -21,9 +22,15 @@ std::unique_ptr<bioparser::Parser<biosoup::NucleicAcid>> CreateParser(
 
 void PrintOverlapBatch(
     std::ostream& ostrm,
-    std::span<const std::unique_ptr<biosoup::NucleicAcid>> batch_targets,
-    std::span<const std::unique_ptr<biosoup::NucleicAcid>> batch_queries,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> targets,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> queries,
     std::span<const std::vector<biosoup::Overlap>> overlaps);
+
+void PrintMatchBatch(
+    std::ostream& ostrm,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> targets,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> queries,
+    std::span<const std::vector<Match>> matches);
 
 }  // namespace ram
 

--- a/include/ram/types.hpp
+++ b/include/ram/types.hpp
@@ -7,6 +7,31 @@
 
 namespace ram {
 
+struct MinimizeConfig {
+  std::uint32_t kmer_length = 15;
+  std::uint32_t window_length = 5;
+  bool minhash = false;
+};
+
+struct ChainConfig {
+  std::uint32_t kmer_length = 15;
+  std::uint32_t bandwidth = 500;
+  std::uint32_t chain = 4;
+  std::uint32_t min_matches = 100;
+  std::uint64_t gap = 10'000;
+};
+
+struct MapToIndexConfig {
+  bool avoid_equal = true;
+  bool avoid_symmetric = true;
+  std::uint32_t occurrence = -1;
+};
+
+struct AlgoConfig {
+  MinimizeConfig minimize;
+  ChainConfig chain;
+};
+
 struct Kmer {
  public:
   Kmer();

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -228,20 +228,19 @@ std::uint32_t CalculateKmerThreshold(std::vector<Index> indices,
   return occurrences[(1 - frequency) * occurrences.size()] + 1;
 }
 
-std::vector<biosoup::Overlap> MapPairs(
-    const std::unique_ptr<biosoup::NucleicAcid>& lhs,
-    const std::unique_ptr<biosoup::NucleicAcid>& rhs,
-    MinimizeConfig minimize_config, ChainConfig chain_config) {
+std::vector<Match> MatchPairs(const std::unique_ptr<biosoup::NucleicAcid>& lhs,
+                              const std::unique_ptr<biosoup::NucleicAcid>& rhs,
+                              MinimizeConfig minimize_config) {
   auto lhs_sketch = Minimize(lhs, minimize_config);
   if (lhs_sketch.empty()) {
-    return std::vector<biosoup::Overlap>{};
+    return std::vector<Match>{};
   }
 
   auto rhs_sketch = Minimize(
       rhs, MinimizeConfig{.kmer_length = minimize_config.kmer_length,
                           .window_length = minimize_config.window_length});
   if (rhs_sketch.empty()) {
-    return std::vector<biosoup::Overlap>{};
+    return std::vector<Match>{};
   }
 
   RadixSort(std::span<Kmer>(lhs_sketch), minimize_config.kmer_length * 2,
@@ -279,7 +278,14 @@ std::vector<biosoup::Overlap> MapPairs(
     }
   }
 
-  return Chain(lhs->id, std::move(matches), chain_config);
+  return matches;
+}
+
+std::vector<biosoup::Overlap> MapPairs(
+    const std::unique_ptr<biosoup::NucleicAcid>& lhs,
+    const std::unique_ptr<biosoup::NucleicAcid>& rhs,
+    MinimizeConfig minimize_config, ChainConfig chain_config) {
+  return Chain(lhs->id, MatchPairs(lhs, rhs, minimize_config), chain_config);
 }
 
 std::vector<biosoup::Overlap> Chain(std::uint64_t lhs_id,
@@ -397,14 +403,14 @@ std::vector<biosoup::Overlap> Chain(std::uint64_t lhs_id,
   return dst;
 }
 
-std::vector<biosoup::Overlap> MapSeqToIndex(
+std::vector<Match> MatchToIndex(
     const std::unique_ptr<biosoup::NucleicAcid>& sequence,
     const std::vector<Index>& indices, MapToIndexConfig map_config,
     MinimizeConfig minimize_config, ChainConfig chain_config,
     std::vector<std::uint32_t>* filtered) {
   auto sketch = Minimize(sequence, minimize_config);
   if (sketch.empty()) {
-    return std::vector<biosoup::Overlap>{};
+    return std::vector<Match>{};
   }
 
   std::vector<Match> matches;
@@ -485,7 +491,18 @@ std::vector<biosoup::Overlap> MapSeqToIndex(
     }
   }
 
-  return Chain(sequence->id, std::move(matches), chain_config);
+  return matches;
+}
+
+std::vector<biosoup::Overlap> MapToIndex(
+    const std::unique_ptr<biosoup::NucleicAcid>& sequence,
+    const std::vector<Index>& indices, MapToIndexConfig map_config,
+    MinimizeConfig minimize_config, ChainConfig chain_config,
+    std::vector<std::uint32_t>* filtered) {
+  return Chain(sequence->id,
+               MatchToIndex(sequence, indices, map_config, minimize_config,
+                            chain_config, filtered),
+               chain_config);
 }
 
 }  // namespace ram

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -405,7 +405,7 @@ std::vector<biosoup::Overlap> Chain(std::uint64_t lhs_id,
 
 std::vector<Match> MatchToIndex(
     const std::unique_ptr<biosoup::NucleicAcid>& sequence,
-    const std::vector<Index>& indices, MapToIndexConfig map_config,
+    std::span<const Index> indices, MapToIndexConfig map_config,
     MinimizeConfig minimize_config, ChainConfig chain_config,
     std::vector<std::uint32_t>* filtered) {
   auto sketch = Minimize(sequence, minimize_config);
@@ -496,7 +496,7 @@ std::vector<Match> MatchToIndex(
 
 std::vector<biosoup::Overlap> MapToIndex(
     const std::unique_ptr<biosoup::NucleicAcid>& sequence,
-    const std::vector<Index>& indices, MapToIndexConfig map_config,
+    std::span<const Index> indices, MapToIndexConfig map_config,
     MinimizeConfig minimize_config, ChainConfig chain_config,
     std::vector<std::uint32_t>* filtered) {
   return Chain(sequence->id,

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -48,18 +48,41 @@ void PrintOverlapBatch(
     std::span<const std::vector<biosoup::Overlap>> overlaps) {
   std::uint64_t rhs_offset = targets.front()->id;
   std::uint64_t lhs_offset = sequences.front()->id;
-  for (auto& it : overlaps) {
+  for (const auto& it : overlaps) {
     for (const auto& jt : it) {
-      ostrm << sequences[jt.lhs_id - lhs_offset]->name << "\t"
-            << sequences[jt.lhs_id - lhs_offset]->inflated_len << "\t"
-            << jt.lhs_begin << "\t" << jt.lhs_end << "\t"
-            << (jt.strand ? "+" : "-") << "\t"
-            << targets[jt.rhs_id - rhs_offset]->name << "\t"
-            << targets[jt.rhs_id - rhs_offset]->inflated_len << "\t"
-            << jt.rhs_begin << "\t" << jt.rhs_end << "\t" << jt.score << "\t"
+      ostrm << sequences[jt.lhs_id - lhs_offset]->name << '\t'
+            << sequences[jt.lhs_id - lhs_offset]->inflated_len << '\t'
+            << jt.lhs_begin << '\t' << jt.lhs_end << '\t'
+            << (jt.strand ? '+' : '-') << "\t"
+            << targets[jt.rhs_id - rhs_offset]->name << '\t'
+            << targets[jt.rhs_id - rhs_offset]->inflated_len << '\t'
+            << jt.rhs_begin << '\t' << jt.rhs_end << '\t' << jt.score << '\t'
             << std::max(jt.lhs_end - jt.lhs_begin, jt.rhs_end - jt.rhs_begin)
-            << "\t" << 255 << std::endl;
+            << '\t' << 255 << '\n';
     }
   }
+
+  std::flush(ostrm);
 }
+
+void PrintMatchBatch(
+    std::ostream& ostrm,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> targets,
+    std::span<const std::unique_ptr<biosoup::NucleicAcid>> sequences,
+    std::span<const std::vector<Match>> matches) {
+  std::uint64_t rhs_offset = targets.front()->id;
+  for (auto lhs_idx = 0uz; lhs_idx < matches.size(); ++lhs_idx) {
+    for (const auto& match : matches[lhs_idx]) {
+      ostrm << sequences[lhs_idx]->name << '\t'
+            << sequences[lhs_idx]->inflated_len << '\t' << match.lhs_position()
+            << '\t' << (match.strand() ? '+' : '-') << '\t'
+            << targets[match.rhs_id() - rhs_offset]->name << '\t'
+            << targets[match.rhs_id() - rhs_offset]->inflated_len << '\t'
+            << match.rhs_position() << '\n';
+    }
+  }
+
+  std::flush(ostrm);
+}
+
 }  // namespace ram

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -1,0 +1,42 @@
+#include "ram/io.hpp"
+
+#include <exception>
+#include <sstream>
+
+#include "bioparser/fasta_parser.hpp"
+#include "bioparser/fastq_parser.hpp"
+#include "biosoup/nucleic_acid.hpp"
+
+std::atomic<std::uint32_t> biosoup::NucleicAcid::num_objects{0};
+
+namespace ram {
+std::unique_ptr<bioparser::Parser<biosoup::NucleicAcid>> CreateParser(
+    const std::string& path) {
+  auto is_suffix = [](const std::string& s, const std::string& suff) {
+    return s.size() < suff.size()
+               ? false
+               : s.compare(s.size() - suff.size(), suff.size(), suff) == 0;
+  };
+
+  if (is_suffix(path, ".fasta") || is_suffix(path, ".fasta.gz") ||
+      is_suffix(path, ".fna") || is_suffix(path, ".fna.gz") ||
+      is_suffix(path, ".fa") || is_suffix(path, ".fa.gz")) {
+    return bioparser::Parser<biosoup::NucleicAcid>::Create<
+        bioparser::FastaParser>(path);  // NOLINT
+  }
+  if (is_suffix(path, ".fastq") || is_suffix(path, ".fastq.gz") ||
+      is_suffix(path, ".fq") || is_suffix(path, ".fq.gz")) {
+    return bioparser::Parser<biosoup::NucleicAcid>::Create<
+        bioparser::FastqParser>(path);  // NOLINT
+  }
+
+  throw std::runtime_error([path] {
+    auto ostrm = std::ostringstream{};
+    ostrm << "[ram::CreateParser] error: file " << path
+          << " has unsupported format extension (valid extensions: .fasta, "
+          << ".fasta.gz, .fna, .fna.gz, .fa, .fa.gz, .fastq, .fastq.gz, "
+          << ".fq, .fq.gz)";
+    return ostrm.str();
+  }());
+}
+}  // namespace ram

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,22 +106,21 @@ int main(int argc, char** argv) {
     auto arena = tbb::task_arena(num_threads);
     biosoup::Timer timer{};
 
-    while (true) {
-      timer.Start();
+    arena.execute([&] {
+      while (true) {
+        timer.Start();
 
-      std::vector<std::unique_ptr<biosoup::NucleicAcid>> targets;
-      targets = tparser->Parse(1ULL << 32);
+        std::vector<std::unique_ptr<biosoup::NucleicAcid>> targets;
+        targets = tparser->Parse(1ULL << 32);
 
-      if (targets.empty()) {
-        break;
-      }
+        if (targets.empty()) {
+          break;
+        }
 
-      std::cerr << "[ram::] parsed " << targets.size() << " targets "
-                << std::fixed << timer.Stop() << "s" << std::endl;
+        std::cerr << "[ram::] parsed " << targets.size() << " targets "
+                  << std::fixed << timer.Stop() << "s" << std::endl;
 
-      timer.Start();
-
-      arena.execute([&] {
+        timer.Start();
         auto indices = ram::ConstructIndices(targets, minimize_cfg);
         auto occurrence = ram::CalculateKmerThreshold(indices, frequency);
 
@@ -130,7 +129,6 @@ int main(int argc, char** argv) {
 
         std::uint64_t num_targets = biosoup::NucleicAcid::num_objects;
         biosoup::NucleicAcid::num_objects = 0;
-
         while (true) {
           timer.Start();
 
@@ -195,8 +193,8 @@ int main(int argc, char** argv) {
 
         sparser->Reset();
         biosoup::NucleicAcid::num_objects = num_targets;
-      });
-    }
+      }
+    });
 
     std::cerr << "[ram::] " << timer.elapsed_time() << "s" << std::endl;
   } catch (const std::exception& exception) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,323 +1,208 @@
 // Copyright (c) 2020 Robert Vaser
 
-#include <getopt.h>
-
 #include <cstdlib>
 #include <iostream>
 #include <mutex>
 
-#include "bioparser/fasta_parser.hpp"
-#include "bioparser/fastq_parser.hpp"
 #include "biosoup/nucleic_acid.hpp"
 #include "biosoup/progress_bar.hpp"
 #include "biosoup/timer.hpp"
+#include "cxxopts.hpp"
 #include "ram/algorithm.hpp"
+#include "ram/io.hpp"
 #include "tbb/tbb.h"
 
-std::atomic<std::uint32_t> biosoup::NucleicAcid::num_objects{0};
-
-namespace {
-
-static struct option options[] = {
-    {"kmer-length", required_argument, nullptr, 'k'},
-    {"window-length", required_argument, nullptr, 'w'},
-    {"frequency-threshold", required_argument, nullptr, 'f'},
-    {"bandwidth", required_argument, nullptr, 'b'},
-    {"chain", required_argument, nullptr, 'c'},
-    {"matches", required_argument, nullptr, 'm'},
-    {"gap", required_argument, nullptr, 'g'},
-    {"minhash", no_argument, nullptr, 'M'},
-    {"threads", required_argument, nullptr, 't'},
-    {"version", no_argument, nullptr, 'v'},
-    {"help", no_argument, nullptr, 'h'},
-    {nullptr, 0, nullptr, 0}};
-
-std::unique_ptr<bioparser::Parser<biosoup::NucleicAcid>> CreateParser(
-    const std::string& path) {
-  auto is_suffix = [](const std::string& s, const std::string& suff) {
-    return s.size() < suff.size()
-               ? false
-               : s.compare(s.size() - suff.size(), suff.size(), suff) == 0;
-  };
-
-  if (is_suffix(path, ".fasta") || is_suffix(path, ".fasta.gz") ||
-      is_suffix(path, ".fna") || is_suffix(path, ".fna.gz") ||
-      is_suffix(path, ".fa") || is_suffix(path, ".fa.gz")) {
-    try {
-      return bioparser::Parser<biosoup::NucleicAcid>::Create<
-          bioparser::FastaParser>(path);  // NOLINT
-    } catch (const std::invalid_argument& exception) {
-      std::cerr << exception.what() << std::endl;
-      return nullptr;
-    }
-  }
-  if (is_suffix(path, ".fastq") || is_suffix(path, ".fastq.gz") ||
-      is_suffix(path, ".fq") || is_suffix(path, ".fq.gz")) {
-    try {
-      return bioparser::Parser<biosoup::NucleicAcid>::Create<
-          bioparser::FastqParser>(path);  // NOLINT
-    } catch (const std::invalid_argument& exception) {
-      std::cerr << exception.what() << std::endl;
-      return nullptr;
-    }
-  }
-
-  std::cerr << "[ram::CreateParser] error: file " << path
-            << " has unsupported format extension (valid extensions: .fasta, "
-            << ".fasta.gz, .fna, .fna.gz, .fa, .fa.gz, .fastq, .fastq.gz, "
-            << ".fq, .fq.gz)" << std::endl;
-  return nullptr;
-}
-
-void Help() {
-  std::cout
-      << "usage: ram [options ...] <target> [<sequences>]\n"
-         "\n"
-         "  # default output is stdout\n"
-         "  <target>/<sequences> \n"
-         "    input file in FASTA/FASTQ format (can be compressed with gzip)\n"
-         "\n"
-         "  options:\n"
-         "    -k, --kmer-length <int>\n"
-         "      default: 15\n"
-         "      length of minimizers\n"
-         "    -w, --window-length <int>\n"
-         "      default: 5\n"
-         "      length of sliding window from which minimizers are sampled\n"
-         "    -f, --frequency-threshold <float>\n"
-         "      default: 0.001\n"
-         "      threshold for ignoring most frequent minimizers\n"
-         "    --bandwidth <int>\n"
-         "      default: 500\n"
-         "      size of bandwidth in which minimizer hits can be chained\n"
-         "    --chain <int>\n"
-         "      default: 4\n"
-         "      minimal number of chained minimizer hits in overlap\n"
-         "    --matches <int>\n"
-         "      default: 100\n"
-         "      minimal number of matching bases in overlap\n"
-         "    --gap <int>\n"
-         "      default: 10000\n"
-         "      maximal gap between minimizer hits in a chain\n"
-         "    --minhash\n"
-         "      use only a portion of all minimizers\n"
-         "    -t, --threads <int>\n"
-         "      default: 1\n"
-         "      number of threads\n"
-         "    --version\n"
-         "      prints the version number\n"
-         "    -h, --help\n"
-         "      prints the usage\n";
-}
-
-}  // namespace
-
 int main(int argc, char** argv) {
-  std::uint32_t k = 15;
-  std::uint32_t w = 5;
-  std::uint32_t bandwidth = 500;
-  std::uint32_t chain = 4;
-  std::uint32_t matches = 100;
-  std::uint32_t gap = 10000;
-  double frequency = 0.001;
-  bool minhash = false;
-  std::uint32_t num_threads = 1;
+  cxxopts::Options options("ram", "sequence mapping tool");
 
-  std::vector<std::string> input_paths;
+  /* clang-format off */
+  options.add_options("algorithm")
+    ("k,kmer-length",
+      "length of minimizers",
+      cxxopts::value<std::uint32_t>()->default_value("15"))
+    ("w,window-length",
+      "length of sliding window from which minimizers are sampled",
+      cxxopts::value<std::uint32_t>()->default_value("5"))
+    ("f,frequency-threshold",
+      "threshold for ignoring most frequent minimizers",
+      cxxopts::value<double>()->default_value("0.001"))
+    ("bandwidth",
+      "size of bandwidth in which minimizer hits can be chained",
+      cxxopts::value<std::uint32_t>()->default_value("500"))
+    ("chain",
+      "minimal number of chained minimizer hits in overlap",
+      cxxopts::value<std::uint32_t>()->default_value("4"))
+    ("matches",
+      "minimal number of matching bases in overlap",
+      cxxopts::value<std::uint32_t>()->default_value("100"))
+    ("gap",
+      "maximal gap between minimizer hits in a chain",
+      cxxopts::value<std::uint64_t>()->default_value("10000"))
+    ("minhash",
+      "use only a portion of all minimizers")
+    ("t,threads",
+      "number of threads",
+      cxxopts::value<std::uint32_t>()->default_value("1"));
+  options.add_options("input")
+    ("inputs", "target and query seuqnces",
+      cxxopts::value<std::vector<std::string>>());
+  options.add_options("info")
+    ("v,version", "print version and exit early")
+    ("h,help", "print help and exit early");
+  options.positional_help("<target> [<query>]");
+  /* clang-format on */
 
-  const char* optstr = "k:w:f:t:h";
-  char arg;
-  while ((arg = getopt_long(argc, argv, optstr, options, nullptr)) != -1) {
-    switch (arg) {
-      case 'k':
-        k = std::atoi(optarg);
-        break;
-      case 'w':
-        w = std::atoi(optarg);
-        break;
-      case 'b':
-        bandwidth = std::atoi(optarg);
-        break;
-      case 'c':
-        chain = std::atoi(optarg);
-        break;
-      case 'm':
-        matches = std::atoi(optarg);
-        break;
-      case 'g':
-        gap = std::atoi(optarg);
-        break;
-      case 'f':
-        frequency = std::atof(optarg);
-        break;
-      case 'M':
-        minhash = true;
-        break;
-      case 't':
-        num_threads = std::atoi(optarg);
-        break;
-      case 'v':
-        std::cout << VERSION << std::endl;
-        return 0;
-      case 'h':
-        Help();
-        return 0;
-      default:
+  try {
+    auto early_quit = false;
+    options.parse_positional({"inputs"});
+    auto parsed_options = options.parse(argc, argv);
+    if (parsed_options.count("version")) {
+      std::cerr << VERSION << std::endl;
+      early_quit = true;
+    }
+
+    if (parsed_options.count("help")) {
+      std::cerr << options.help() << std::endl;
+      early_quit = true;
+    }
+
+    if (early_quit) {
+      return 0;
+    }
+
+    auto input_paths = parsed_options["inputs"].as<std::vector<std::string>>();
+    auto tparser = ram::CreateParser(input_paths[0]);
+
+    auto is_ava = input_paths.size() == 1uz;
+    std::unique_ptr<bioparser::Parser<biosoup::NucleicAcid>> sparser = nullptr;
+    if (input_paths.size() > 1) {
+      sparser = ram::CreateParser(input_paths[1]);
+      if (sparser == nullptr) {
         return 1;
+      }
+      is_ava = input_paths[0] == input_paths[1];
+    } else {
+      sparser = ram::CreateParser(input_paths[0]);
+      is_ava = true;
     }
-  }
 
-  if (argc == 1) {
-    Help();
-    return 0;
-  }
+    auto num_threads = parsed_options["threads"].as<std::uint32_t>();
+    auto frequency = parsed_options["frequency-threshold"].as<double>();
 
-  for (auto i = optind; i < argc; ++i) {
-    input_paths.emplace_back(argv[i]);
-  }
+    auto minimize_cfg = ram::MinimizeConfig{
+        .kmer_length = parsed_options["kmer-length"].as<std::uint32_t>(),
+        .window_length = parsed_options["window-length"].as<std::uint32_t>(),
+        .minhash = parsed_options["minhash"].as<bool>(),
+    };
 
-  if (input_paths.empty()) {
-    std::cerr << "[ram::] error: missing target file" << std::endl;
-    return 1;
-  }
+    auto chain_cfg = ram::ChainConfig{
+        .kmer_length = parsed_options["kmer-length"].as<std::uint32_t>(),
+        .bandwidth = parsed_options["bandwidth"].as<std::uint32_t>(),
+        .chain = parsed_options["chain"].as<std::uint32_t>(),
+        .min_matches = parsed_options["matches"].as<std::uint32_t>(),
+        .gap = parsed_options["gap"].as<std::uint64_t>(),
+    };
 
-  auto tparser = CreateParser(input_paths[0]);
-  if (tparser == nullptr) {
-    return 1;
-  }
+    auto arena = tbb::task_arena(num_threads);
+    biosoup::Timer timer{};
 
-  bool is_ava = false;
-  std::unique_ptr<bioparser::Parser<biosoup::NucleicAcid>> sparser = nullptr;
-  if (input_paths.size() > 1) {
-    sparser = CreateParser(input_paths[1]);
-    if (sparser == nullptr) {
-      return 1;
-    }
-    is_ava = input_paths[0] == input_paths[1];
-  } else {
-    sparser = CreateParser(input_paths[0]);
-    is_ava = true;
-  }
+    while (true) {
+      timer.Start();
 
-  auto arena = tbb::task_arena(num_threads);
-  biosoup::Timer timer{};
-
-  while (true) {
-    timer.Start();
-
-    std::vector<std::unique_ptr<biosoup::NucleicAcid>> targets;
-    try {
+      std::vector<std::unique_ptr<biosoup::NucleicAcid>> targets;
       targets = tparser->Parse(1ULL << 32);
-    } catch (std::invalid_argument& exception) {
-      std::cerr << exception.what() << std::endl;
-      return 1;
-    }
 
-    if (targets.empty()) {
-      break;
-    }
-
-    std::cerr << "[ram::] parsed " << targets.size() << " targets "
-              << std::fixed << timer.Stop() << "s" << std::endl;
-
-    timer.Start();
-
-    arena.execute([&] {
-      auto indices = ram::ConstructIndices(targets, ram::MinimizeConfig{
-                                                        .kmer_length = k,
-                                                        .window_length = w,
-                                                        .minhash = minhash,
-                                                    });
-      auto occurrence = ram::CalculateKmerThreshold(indices, frequency);
-
-      std::cerr << "[ram::] minimized targets " << std::fixed << timer.Stop()
-                << "s" << std::endl;
-
-      std::uint64_t num_targets = biosoup::NucleicAcid::num_objects;
-      biosoup::NucleicAcid::num_objects = 0;
-
-      while (true) {
-        timer.Start();
-
-        std::vector<std::unique_ptr<biosoup::NucleicAcid>> sequences;
-        try {
-          sequences = sparser->Parse(1U << 30);
-        } catch (std::invalid_argument& exception) {
-          std::cerr << exception.what() << std::endl;
-          exit(1);
-        }
-
-        if (sequences.empty()) {
-          break;
-        }
-
-        biosoup::ProgressBar bar{static_cast<std::uint32_t>(sequences.size()),
-                                 16};
-        auto update_progress = [&timer, &bar, mtx = std::mutex{}] mutable {
-          std::lock_guard lk{mtx};
-          if (++bar) {
-            std::cerr << "[ram::] mapped " << bar.event_counter()
-                      << " sequences "
-                      << "[" << bar << "] " << std::fixed << timer.Lap() << "s"
-                      << "\r";
-          }
-        };
-
-        std::vector<std::vector<biosoup::Overlap>> overlaps(sequences.size());
-        tbb::parallel_for(0uz, sequences.size(), [&](std::size_t idx) -> void {
-          overlaps[idx] = ram::MapSeqToIndex(sequences[idx], indices,
-                                             ram::MapToIndexConfig{
-                                                 .avoid_equal = is_ava,
-                                                 .avoid_symmetric = is_ava,
-                                                 .occurrence = occurrence,
-                                             },
-                                             ram::MinimizeConfig{
-                                                 .kmer_length = k,
-                                                 .window_length = w,
-                                                 .minhash = minhash,
-                                             },
-                                             ram::ChainConfig{
-                                                 .kmer_length = k,
-                                                 .bandwidth = bandwidth,
-                                                 .chain = chain,
-                                                 .min_matches = matches,
-                                                 .gap = gap,
-                                             },
-                                             nullptr);
-          update_progress();
-        });
-
-        std::uint64_t rhs_offset = targets.front()->id;
-        std::uint64_t lhs_offset = sequences.front()->id;
-        for (auto& it : overlaps) {
-          for (const auto& jt : it) {
-            std::cout << sequences[jt.lhs_id - lhs_offset]->name << "\t"
-                      << sequences[jt.lhs_id - lhs_offset]->inflated_len << "\t"
-                      << jt.lhs_begin << "\t" << jt.lhs_end << "\t"
-                      << (jt.strand ? "+" : "-") << "\t"
-                      << targets[jt.rhs_id - rhs_offset]->name << "\t"
-                      << targets[jt.rhs_id - rhs_offset]->inflated_len << "\t"
-                      << jt.rhs_begin << "\t" << jt.rhs_end << "\t" << jt.score
-                      << "\t"
-                      << std::max(jt.lhs_end - jt.lhs_begin,
-                                  jt.rhs_end - jt.rhs_begin)
-                      << "\t" << 255 << std::endl;
-          }
-        }
-        std::cerr << std::endl;
-        timer.Stop();
-
-        if (is_ava && biosoup::NucleicAcid::num_objects >= num_targets) {
-          break;
-        }
+      if (targets.empty()) {
+        break;
       }
 
-      sparser->Reset();
-      biosoup::NucleicAcid::num_objects = num_targets;
-    });
-  }
+      std::cerr << "[ram::] parsed " << targets.size() << " targets "
+                << std::fixed << timer.Stop() << "s" << std::endl;
 
-  std::cerr << "[ram::] " << timer.elapsed_time() << "s" << std::endl;
+      timer.Start();
+
+      arena.execute([&] {
+        auto indices = ram::ConstructIndices(targets, minimize_cfg);
+        auto occurrence = ram::CalculateKmerThreshold(indices, frequency);
+
+        std::cerr << "[ram::] minimized targets " << std::fixed << timer.Stop()
+                  << "s" << std::endl;
+
+        std::uint64_t num_targets = biosoup::NucleicAcid::num_objects;
+        biosoup::NucleicAcid::num_objects = 0;
+
+        while (true) {
+          timer.Start();
+
+          std::vector<std::unique_ptr<biosoup::NucleicAcid>> sequences;
+          sequences = sparser->Parse(1U << 30);
+
+          if (sequences.empty()) {
+            break;
+          }
+
+          biosoup::ProgressBar bar{static_cast<std::uint32_t>(sequences.size()),
+                                   16};
+          auto update_progress = [&timer, &bar, mtx = std::mutex{}] mutable {
+            std::lock_guard lk{mtx};
+            if (++bar) {
+              std::cerr << "[ram::] mapped " << bar.event_counter()
+                        << " sequences "
+                        << "[" << bar << "] " << std::fixed << timer.Lap()
+                        << "s"
+                        << "\r";
+            }
+          };
+
+          std::vector<std::vector<biosoup::Overlap>> overlaps(sequences.size());
+          tbb::parallel_for(
+              0uz, sequences.size(), [&](std::size_t idx) -> void {
+                overlaps[idx] =
+                    ram::MapSeqToIndex(sequences[idx], indices,
+                                       ram::MapToIndexConfig{
+                                           .avoid_equal = is_ava,
+                                           .avoid_symmetric = is_ava,
+                                           .occurrence = occurrence,
+                                       },
+                                       minimize_cfg, chain_cfg, nullptr);
+                update_progress();
+              });
+
+          std::uint64_t rhs_offset = targets.front()->id;
+          std::uint64_t lhs_offset = sequences.front()->id;
+          for (auto& it : overlaps) {
+            for (const auto& jt : it) {
+              std::cout << sequences[jt.lhs_id - lhs_offset]->name << "\t"
+                        << sequences[jt.lhs_id - lhs_offset]->inflated_len
+                        << "\t" << jt.lhs_begin << "\t" << jt.lhs_end << "\t"
+                        << (jt.strand ? "+" : "-") << "\t"
+                        << targets[jt.rhs_id - rhs_offset]->name << "\t"
+                        << targets[jt.rhs_id - rhs_offset]->inflated_len << "\t"
+                        << jt.rhs_begin << "\t" << jt.rhs_end << "\t"
+                        << jt.score << "\t"
+                        << std::max(jt.lhs_end - jt.lhs_begin,
+                                    jt.rhs_end - jt.rhs_begin)
+                        << "\t" << 255 << std::endl;
+            }
+          }
+          std::cerr << std::endl;
+          timer.Stop();
+
+          if (is_ava && biosoup::NucleicAcid::num_objects >= num_targets) {
+            break;
+          }
+        }
+
+        sparser->Reset();
+        biosoup::NucleicAcid::num_objects = num_targets;
+      });
+    }
+
+    std::cerr << "[ram::] " << timer.elapsed_time() << "s" << std::endl;
+  } catch (const std::exception& exception) {
+    std::cerr << exception.what() << std::endl;
+    return 1;
+  }
 
   return 0;
 }

--- a/test/minimizer_engine_test.cpp
+++ b/test/minimizer_engine_test.cpp
@@ -27,7 +27,7 @@ TEST_F(RamMinimizerEngineTest, Map) {
   auto indices = ConstructIndices(s, MinimizeConfig{});
   auto occurrence = CalculateKmerThreshold(indices, 0.001);
 
-  auto o = MapSeqToIndex(s.front(), indices,
+  auto o = MapToIndex(s.front(), indices,
                          MapToIndexConfig{.occurrence = occurrence},
                          MinimizeConfig{}, ChainConfig{}, nullptr);
   EXPECT_EQ(1, o.size());
@@ -40,12 +40,12 @@ TEST_F(RamMinimizerEngineTest, Map) {
   EXPECT_EQ(585, o.front().score);
   EXPECT_TRUE(o.front().strand);
 
-  o = MapSeqToIndex(s.back(), indices,
+  o = MapToIndex(s.back(), indices,
                     MapToIndexConfig{.occurrence = occurrence},
                     MinimizeConfig{}, ChainConfig{}, nullptr);
   EXPECT_TRUE(o.empty());
 
-  o = MapSeqToIndex(
+  o = MapToIndex(
       s.back(), indices,
       MapToIndexConfig{.avoid_symmetric = false, .occurrence = occurrence},
       MinimizeConfig{}, ChainConfig{}, nullptr);
@@ -60,7 +60,7 @@ TEST_F(RamMinimizerEngineTest, Map) {
   EXPECT_EQ(585, o.front().score);
   EXPECT_TRUE(o.front().strand);
 
-  o = MapSeqToIndex(s.front(), indices,
+  o = MapToIndex(s.front(), indices,
                     MapToIndexConfig{.avoid_equal = false,
                                      .avoid_symmetric = true,
                                      .occurrence = occurrence},
@@ -106,7 +106,7 @@ TEST_F(RamMinimizerEngineTest, Filter) {
   auto occurrence_0_001 = CalculateKmerThreshold(indices, 0.001);
   std::vector<std::uint32_t> filtered;
 
-  auto o = MapSeqToIndex(
+  auto o = MapToIndex(
       s.front(), indices, MapToIndexConfig{.occurrence = occurrence_0_001},
       minimize_config, ChainConfig{.kmer_length = 9}, &filtered);
 
@@ -122,7 +122,7 @@ TEST_F(RamMinimizerEngineTest, Filter) {
 
   auto occurrence_0_1 = CalculateKmerThreshold(indices, 0.1);
 
-  o = MapSeqToIndex(s.front(), indices,
+  o = MapToIndex(s.front(), indices,
                     MapToIndexConfig{.occurrence = occurrence_0_1},
                     minimize_config, ChainConfig{.kmer_length = 9}, &filtered);
   EXPECT_EQ(1, o.size());
@@ -141,7 +141,7 @@ TEST_F(RamMinimizerEngineTest, Micromize) {
   std::vector<std::uint32_t> filtered;
 
   auto o =
-      MapSeqToIndex(s.front(), indices, MapToIndexConfig{},
+      MapToIndex(s.front(), indices, MapToIndexConfig{},
                     MinimizeConfig{.minhash = true}, ChainConfig{}, &filtered);
 
   EXPECT_EQ(1, o.size());


### PR DESCRIPTION
# Ram modes

## Description

Standard overlap output from ram mapper doesn't contain enough information for assigning a confidence level to overlaps. The idea is to provide different work/output modes. This PR introduces `match` mode. In match mode the mapper outputs are k-mer level matches which are used in chaining procedure. This provides the end user with:
- more insight into retrieved matches
- ability to run additional analysis on matches
- use custom chaining/overlap construction method

## Future goals
1. Implement `chaining` mode. Outputs annotated match chains which would be used for constructing overlaps. The idea is to output all chains, even the ones which are deemed too short or slightly off the diagonal.
2. Implement `index` mode. `Index` mode would allow a user to load an already prebuild k-mer indices.